### PR TITLE
Save the tool proxy on the consumer

### DIFF
--- a/src/ToolProvider/ToolProvider.php
+++ b/src/ToolProvider/ToolProvider.php
@@ -431,6 +431,7 @@ class ToolProvider
         if ($ok) {
             $this->consumer->setKey($http->responseJson->tool_proxy_guid);
             $this->consumer->secret = $toolProxy->security_contract->shared_secret;
+            $this->consumer->toolProxy = json_encode($toolProxy);
             $this->consumer->save();
         }
 


### PR DESCRIPTION
The toolProxy string is empty. It's useful for the provider to know what proxy it gave the consumer. Should we save it when we set the key and secret?