### PR TITLE
Import DataConnector class

### DIFF
--- a/src/ToolProvider/ResourceLinkShareKey.php
+++ b/src/ToolProvider/ResourceLinkShareKey.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 
 /**
  * Class to represent a tool consumer resource link share key


### PR DESCRIPTION
Hello,

I was extending the DataConnector class and I encountered the error 
`Error: Class 'IMSGlobal\LTI\ToolProvider\DataConnector' not found` 
when I tried calling ResourceLinkShareKey's save() method.

I provided a simple patch that imports `IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector` into `src/ToolProvider/ResourceLinkShareKey.php`.