### PR TITLE
Updated PHPDoc blocks

### DIFF
--- a/src/ToolProvider/ConsumerNonce.php
+++ b/src/ToolProvider/ConsumerNonce.php
@@ -22,7 +22,7 @@ class ConsumerNonce
 /**
  * Date/time when the nonce value expires.
  *
- * @var datetime $expires
+ * @var int $expires
  */
     public $expires = null;
 

--- a/src/ToolProvider/ContentItem.php
+++ b/src/ToolProvider/ContentItem.php
@@ -106,7 +106,8 @@ class ContentItem
 /**
  * Wrap the content items to form a complete application/vnd.ims.lti.v1.contentitems+json media type instance.
  *
- * @param mixed $items  An array of content items or a single item
+ * @param mixed $items An array of content items or a single item
+ * @return string
  */
     public static function toJson($items)
     {

--- a/src/ToolProvider/Context.php
+++ b/src/ToolProvider/Context.php
@@ -2,6 +2,7 @@
 
 namespace IMSGlobal\LTI\ToolProvider;
 
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 use IMSGlobal\LTI\ToolProvider\Service;
 
 /**
@@ -37,13 +38,13 @@ class Context
 /**
  * Date/time when the object was created.
  *
- * @var datetime $created
+ * @var int $created
  */
     public $created = null;
 /**
  * Date/time when the object was last updated.
  *
- * @var datetime $updated
+ * @var int $updated
  */
     public $updated = null;
 
@@ -417,8 +418,9 @@ class Context
 /**
  * Class constructor from consumer.
  *
- * @param LTIToolConsumer $consumer       Consumer instance
- * @param string          $ltiContextId   LTI Context ID value
+ * @param ToolConsumer $consumer Consumer instance
+ * @param string $ltiContextId LTI Context ID value
+ * @return Context
  */
     public static function fromConsumer($consumer, $ltiContextId)
     {

--- a/src/ToolProvider/DataConnector/DataConnector.php
+++ b/src/ToolProvider/DataConnector/DataConnector.php
@@ -2,6 +2,13 @@
 
 namespace IMSGlobal\LTI\ToolProvider\DataConnector;
 
+use IMSGlobal\LTI\ToolProvider\ConsumerNonce;
+use IMSGlobal\LTI\ToolProvider\Context;
+use IMSGlobal\LTI\ToolProvider\ResourceLink;
+use IMSGlobal\LTI\ToolProvider\ResourceLinkShareKey;
+use IMSGlobal\LTI\ToolProvider\ToolConsumer;
+use IMSGlobal\LTI\ToolProvider\ToolProxy;
+use IMSGlobal\LTI\ToolProvider\User;
 use PDO;
 
 /**
@@ -577,10 +584,9 @@ class DataConnector
  * Any single quotes in the value passed will be replaced with two single quotes.  If a null value is passed, a string
  * of 'null' is returned (which will never be enclosed in quotes irrespective of the value of the $addQuotes parameter.
  *
- * @param string $value     Value to be quoted
- * @param string $addQuotes If true the returned string will be enclosed in single quotes (optional, default is true)
- *
- * @return boolean True if the user object was successfully deleted
+ * @param string $value Value to be quoted
+ * @param bool $addQuotes If true the returned string will be enclosed in single quotes (optional, default is true)
+ * @return string The quoted string.
  */
     static function quoted($value, $addQuotes = true)
     {

--- a/src/ToolProvider/DataConnector/DataConnector_mysql.php
+++ b/src/ToolProvider/DataConnector/DataConnector_mysql.php
@@ -3,6 +3,12 @@
 namespace IMSGlobal\LTI\ToolProvider\DataConnector;
 
 use IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\ToolProvider\ConsumerNonce;
+use IMSGlobal\LTI\ToolProvider\Context;
+use IMSGlobal\LTI\ToolProvider\ResourceLink;
+use IMSGlobal\LTI\ToolProvider\ResourceLinkShareKey;
+use IMSGlobal\LTI\ToolProvider\ToolConsumer;
+use IMSGlobal\LTI\ToolProvider\User;
 
 /**
  * Class to represent an LTI Data Connector for MySQL

--- a/src/ToolProvider/DataConnector/DataConnector_pdo.php
+++ b/src/ToolProvider/DataConnector/DataConnector_pdo.php
@@ -3,6 +3,12 @@
 namespace IMSGlobal\LTI\ToolProvider\DataConnector;
 
 use IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\ToolProvider\ConsumerNonce;
+use IMSGlobal\LTI\ToolProvider\Context;
+use IMSGlobal\LTI\ToolProvider\ResourceLink;
+use IMSGlobal\LTI\ToolProvider\ResourceLinkShareKey;
+use IMSGlobal\LTI\ToolProvider\ToolConsumer;
+use IMSGlobal\LTI\ToolProvider\User;
 use PDO;
 
 /**

--- a/src/ToolProvider/DataConnector/DataConnector_pdo_sqlite.php
+++ b/src/ToolProvider/DataConnector/DataConnector_pdo_sqlite.php
@@ -3,6 +3,8 @@
 namespace IMSGlobal\LTI\ToolProvider\DataConnector;
 
 use IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\ToolProvider\Context;
+use IMSGlobal\LTI\ToolProvider\ToolConsumer;
 use PDO;
 
 /**

--- a/src/ToolProvider/MediaType/ResourceHandler.php
+++ b/src/ToolProvider/MediaType/ResourceHandler.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace IMSGlobal\LTI\ToolProvider\MediaType;
+use IMSGlobal\LTI\ToolProvider\ToolProvider;
+use IMSGlobal\LTI\Profile\ResourceHandler as ProfileResourceHandler;
 
 /**
  * Class to represent an LTI Resource Handler
@@ -18,7 +20,7 @@ class ResourceHandler
  * Class constructor.
  *
  * @param ToolProvider $toolProvider   Tool Provider object
- * @param resourceHandler $resourceHandler   Resource handler object
+ * @param ProfileResourceHandler $resourceHandler   Resource handler object
  */
     function __construct($toolProvider, $resourceHandler)
     {

--- a/src/ToolProvider/MediaType/SecurityContract.php
+++ b/src/ToolProvider/MediaType/SecurityContract.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace IMSGlobal\LTI\ToolProvider\MediaType;
+use IMSGlobal\LTI\ToolProvider\ToolProvider;
 
 /**
  * Class to represent an LTI Security Contract document

--- a/src/ToolProvider/MediaType/ToolProfile.php
+++ b/src/ToolProvider/MediaType/ToolProfile.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace IMSGlobal\LTI\ToolProvider\MediaType;
+use IMSGlobal\LTI\ToolProvider\ToolProvider;
 
 /**
  * Class to represent an LTI Tool Profile

--- a/src/ToolProvider/MediaType/ToolProxy.php
+++ b/src/ToolProvider/MediaType/ToolProxy.php
@@ -2,7 +2,8 @@
 
 namespace IMSGlobal\LTI\ToolProvider\MediaType;
 
-use IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\Profile\ServiceDefinition;
+use IMSGlobal\LTI\ToolProvider\ToolProvider;
 
 /**
  * Class to represent an LTI Tool Proxy media type

--- a/src/ToolProvider/Outcome.php
+++ b/src/ToolProvider/Outcome.php
@@ -29,7 +29,7 @@ class Outcome
 /**
  * Outcome date value.
  *
- * @var datetime $date
+ * @var string $date
  */
     public $date = null;
 /**

--- a/src/ToolProvider/ResourceLink.php
+++ b/src/ToolProvider/ResourceLink.php
@@ -2,6 +2,9 @@
 
 namespace IMSGlobal\LTI\ToolProvider;
 
+use DOMDocument;
+use DOMElement;
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 use IMSGlobal\LTI\ToolProvider\Service;
 use IMSGlobal\LTI\HTTPMessage;
 use IMSGlobal\LTI\OAuth;
@@ -131,13 +134,13 @@ class ResourceLink
 /**
  * Date/time when the object was created.
  *
- * @var dateime $created
+ * @var int $created
  */
     public $created = null;
 /**
  * Date/time when the object was last updated.
  *
- * @var datetime $updated
+ * @var int $updated
  */
     public $updated = null;
 
@@ -959,9 +962,10 @@ EOF;
 /**
  * Class constructor from consumer.
  *
- * @param ToolConsumer $consumer            Consumer object
- * @param string $ltiResourceLinkId         Resource link ID value
- * @param string $tempId                    Temporary Resource link ID value (optional, default is null)
+ * @param ToolConsumer $consumer Consumer object
+ * @param string $ltiResourceLinkId Resource link ID value
+ * @param string $tempId Temporary Resource link ID value (optional, default is null)
+ * @return ResourceLink
  */
     public static function fromConsumer($consumer, $ltiResourceLinkId, $tempId = null)
     {
@@ -986,9 +990,10 @@ EOF;
 /**
  * Class constructor from context.
  *
- * @param Context   $context                   Context object
- * @param string    $ltiResourceLinkId         Resource link ID value
- * @param string    $tempId                    Temporary Resource link ID value (optional, default is null)
+ * @param Context $context Context object
+ * @param string $ltiResourceLinkId Resource link ID value
+ * @param string $tempId Temporary Resource link ID value (optional, default is null)
+ * @return ResourceLink
  */
     public static function fromContext($context, $ltiResourceLinkId, $tempId = null)
     {
@@ -1092,13 +1097,13 @@ EOF;
                 if (in_array(self::EXT_TYPE_LETTER_AF_PLUS, $supportedTypes)) {
                     $ok = true;
                     $ltiOutcome->type = self::EXT_TYPE_LETTER_AF_PLUS;
-                } else if (in_array(self::EXT_TYPE_TEXT, $supporteTypes)) {
+                } else if (in_array(self::EXT_TYPE_TEXT, $supportedTypes)) {
                     $ok = true;
                     $ltiOutcome->type = self::EXT_TYPE_TEXT;
                 }
 // Convert letter_af_plus to letter_af or text
             } else if ($type === self::EXT_TYPE_LETTER_AF_PLUS) {
-                if (in_array(self::EXT_TYPE_LETTER_AF, $supported_types) && (strlen($value) === 1)) {
+                if (in_array(self::EXT_TYPE_LETTER_AF, $supportedTypes) && (strlen($value) === 1)) {
                     $ok = true;
                     $ltiOutcome->type = self::EXT_TYPE_LETTER_AF;
                 } else if (in_array(self::EXT_TYPE_TEXT, $supportedTypes)) {
@@ -1155,7 +1160,7 @@ EOF;
                 $this->extResponse = $http->response;
                 $this->extResponseHeaders = $http->responseHeaders;
                 try {
-                    $this->extDoc = new \DOMDocument();
+                    $this->extDoc = new DOMDocument();
                     $this->extDoc->loadXML($http->response);
                     $this->extNodes = $this->domnodeToArray($this->extDoc->documentElement);
                     if (isset($this->extNodes['statusinfo']['codemajor']) && ($this->extNodes['statusinfo']['codemajor'] === 'Success')) {
@@ -1226,7 +1231,7 @@ EOD;
                 $this->extResponse = $http->response;
                 $this->extResponseHeaders = $http->responseHeaders;
                 try {
-                    $this->extDoc = new \DOMDocument();
+                    $this->extDoc = new DOMDocument();
                     $this->extDoc->loadXML($http->response);
                     $this->extNodes = $this->domnodeToArray($this->extDoc->documentElement);
                     if (isset($this->extNodes['imsx_POXHeader']['imsx_POXResponseHeaderInfo']['imsx_statusInfo']['imsx_codeMajor']) &&

--- a/src/ToolProvider/ResourceLinkShareKey.php
+++ b/src/ToolProvider/ResourceLinkShareKey.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 
 /**
  * Class to represent a tool consumer resource link share key
@@ -58,7 +59,7 @@ class ResourceLinkShareKey
 /**
  * Date/time when the share key expires.
  *
- * @var datetime $expires
+ * @var int $expires
  */
     public $expires = null;
 

--- a/src/ToolProvider/ToolConsumer.php
+++ b/src/ToolProvider/ToolConsumer.php
@@ -2,7 +2,7 @@
 
 namespace IMSGlobal\LTI\ToolProvider;
 
-use IMSGlobal\LTI\ToolProvider\DataConnector;
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 use IMSGlobal\LTI\ToolProvider\Service;
 use IMSGlobal\LTI\HTTPMessage;
 use IMSGlobal\LTI\OAuth;
@@ -76,19 +76,19 @@ class ToolConsumer
 /**
  * Date/time from which the the tool consumer instance is enabled to accept incoming connection requests.
  *
- * @var datetime $enableFrom
+ * @var int $enableFrom
  */
     public $enableFrom = null;
 /**
  * Date/time until which the tool consumer instance is enabled to accept incoming connection requests.
  *
- * @var datetime $enableUntil
+ * @var int $enableUntil
  */
     public $enableUntil = null;
 /**
  * Date of last connection from this tool consumer.
  *
- * @var datetime $lastAccess
+ * @var int $lastAccess
  */
     public $lastAccess = null;
 /**
@@ -112,13 +112,13 @@ class ToolConsumer
 /**
  * Date/time when the object was created.
  *
- * @var datetime $created
+ * @var int $created
  */
     public $created = null;
 /**
  * Date/time when the object was last updated.
  *
- * @var datetime $updated
+ * @var int $updated
  */
     public $updated = null;
 
@@ -151,7 +151,7 @@ class ToolConsumer
  * Class constructor.
  *
  * @param string  $key             Consumer key
- * @param mixed   $dataConnector   A data connector object
+ * @param DataConnector   $dataConnector   A data connector object
  * @param boolean $autoEnable      true if the tool consumers is to be enabled automatically (optional, default is false)
  */
     public function __construct($key = null, $dataConnector = null, $autoEnable = false)
@@ -159,13 +159,13 @@ class ToolConsumer
 
         $this->initialize();
         if (empty($dataConnector)) {
-            $dataConnector = DataConnector\DataConnector::getDataConnector();
+            $dataConnector = DataConnector::getDataConnector();
         }
         $this->dataConnector = $dataConnector;
         if (!empty($key)) {
             $this->load($key, $autoEnable);
         } else {
-            $this->secret = DataConnector\DataConnector::getRandomString(32);
+            $this->secret = DataConnector::getRandomString(32);
         }
 
     }

--- a/src/ToolProvider/ToolProvider.php
+++ b/src/ToolProvider/ToolProvider.php
@@ -2,7 +2,8 @@
 
 namespace IMSGlobal\LTI\ToolProvider;
 
-use IMSGlobal\LTI\ToolProvider\DataConnector;
+use IMSGlobal\LTI\Profile\Item;
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 use IMSGlobal\LTI\ToolProvider\MediaType;
 use IMSGlobal\LTI\Profile;
 use IMSGlobal\LTI\HTTPMessage;
@@ -424,7 +425,7 @@ class ToolProvider
 
 // Create tool proxy
         $toolProxyService = $this->findService('application/vnd.ims.lti.v2.toolproxy+json', array('POST'));
-        $secret = DataConnector\DataConnector::getRandomString(12);
+        $secret = DataConnector::getRandomString(12);
         $toolProxy = new MediaType\ToolProxy($this, $toolProxyService, $secret);
         $http = $this->consumer->doServiceRequest($toolProxyService, 'POST', 'application/vnd.ims.lti.v2.toolproxy+json', json_encode($toolProxy));
         $ok = $http->ok && ($http->status == 201) && isset($http->responseJson->tool_proxy_guid) && (strlen($http->responseJson->tool_proxy_guid) > 0);
@@ -469,9 +470,10 @@ class ToolProvider
 /**
  * Generate a web page containing an auto-submitted form of parameters.
  *
- * @param string $url         URL to which the form should be submitted
- * @param array    $params    Array of form parameters
- * @param string $target    Name of target (optional)
+ * @param string $url URL to which the form should be submitted
+ * @param array $params Array of form parameters
+ * @param string $target Name of target (optional)
+ * @return string
  */
     public static function sendForm($url, $params, $target = '')
     {
@@ -1180,7 +1182,7 @@ EOD;
             } else {
 // Check if this is a new share key
                 $shareKey = new ResourceLinkShareKey($this->resourceLink, $_POST['custom_share_key']);
-                if (!is_null($shareKey->primaryConsumerKey) && !is_null($share_key->primaryResourceLinkId)) {
+                if (!is_null($shareKey->primaryConsumerKey) && !is_null($shareKey->primaryResourceLinkId)) {
 // Update resource link with sharing primary resource link details
                     $key = $shareKey->primaryConsumerKey;
                     $id = $shareKey->primaryResourceLinkId;

--- a/src/ToolProvider/ToolProxy.php
+++ b/src/ToolProvider/ToolProxy.php
@@ -2,8 +2,8 @@
 
 namespace IMSGlobal\LTI\ToolProvider;
 
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 use IMSGlobal\LTI\ToolProvider\MediaType;
-use IMSGlobal\LTI\ToolProvider\DataConnector;
 
 /**
  * Class to represent an LTI Tool Proxy
@@ -45,7 +45,7 @@ class ToolProxy
 /**
  * Data connector object.
  *
- * @var DataConnector\DataConnector $dataConnector
+ * @var DataConnector $dataConnector
  */
     private $dataConnector = null;
 /**
@@ -58,7 +58,7 @@ class ToolProxy
 /**
  * Class constructor.
  *
- * @param DataConnector\DataConnector   $dataConnector   Data connector
+ * @param DataConnector   $dataConnector   Data connector
  * @param string                        $id              Tool Proxy ID (optional, default is null)
  */
     public function __construct($dataConnector, $id = null)
@@ -69,7 +69,7 @@ class ToolProxy
         if (!empty($id)) {
             $this->load($id);
         } else {
-            $this->recordId = DataConnector\DataConnector::getRandomString(32);
+            $this->recordId = DataConnector::getRandomString(32);
         }
 
     }

--- a/src/ToolProvider/User.php
+++ b/src/ToolProvider/User.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace IMSGlobal\LTI\ToolProvider;
+use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 
 /**
  * Class to represent a tool consumer user
@@ -175,7 +176,7 @@ class User
 /**
  * Get resource link.
  *
- * @return LTIResourceLink Resource link object
+ * @return ResourceLink Resource link object
  */
     public function getResourceLink()
     {
@@ -398,8 +399,9 @@ class User
 /**
  * Class constructor from resource link.
  *
- * @param ResourceLink $resourceLink   Resource_Link object
- * @param string       $ltiUserId      User ID value
+ * @param ResourceLink $resourceLink Resource_Link object
+ * @param string $ltiUserId User ID value
+ * @return User
  */
     public static function fromResourceLink($resourceLink, $ltiUserId)
     {
@@ -455,9 +457,10 @@ class User
         $this->id = $id;
         $dataConnector = $this->getDataConnector();
         if (!is_null($dataConnector)) {
-            $dataConnector->loadUser($this);
+            return $dataConnector->loadUser($this);
         }
 
+        return false;
     }
 
 }


### PR DESCRIPTION
* Imported classes declared in the doc blocks to
  - ensure proper class loading;  and
  - help make the library become more IDE-friendly.
* Added some fixes also about mistyped variables.
  - $shareKey in ToolProvider::checkForShare()
  - $supporteTypes in ResourceLink::checkValueType
* Fixed/added return tags of some of the methods.
* Fixed class name declaration of some method parameters.
* Changed type definition of some variables:
  - 'datetime' to 'int' for timestamp variables.
  - 'datetime' to 'string' for Outcome::date.