### PR TITLE
Disabled CURL SSLv3

### DIFF
--- a/src/HTTPMessage.php
+++ b/src/HTTPMessage.php
@@ -132,7 +132,7 @@ class HTTPMessage
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLINFO_HEADER_OUT, true);
             curl_setopt($ch, CURLOPT_HEADER, true);
-            curl_setopt($ch, CURLOPT_SSLVERSION,3);
+            //curl_setopt($ch, CURLOPT_SSLVERSION,3);
             $chResp = curl_exec($ch);
             $this->ok = $chResp !== false;
             if ($this->ok) {


### PR DESCRIPTION
SSLv3 is not secure and rejected by some Tool Consumers. 

I ran into this issue while implementing an LTI integration with the University of Toronto's BlackBoard/Learn LMS. Specifically calls to the memberships service failed because of the unsupported SSL version. Most consumers (should) have disabled SSLv3 connections due to an inherent vulnerability in the protocol. The PHP CURL manual recommends leaving this option unset to use the default (see CURLOPT_SSLVERSION in http://php.net/manual/en/function.curl-setopt.php).