### PR TITLE
Added the ability to pass text and URL parameters to the Outcome

### DIFF
--- a/src/ToolProvider/Outcome.php
+++ b/src/ToolProvider/Outcome.php
@@ -51,16 +51,22 @@ class Outcome
  * @var string $value
  */
     private $value = null;
+    private $text = null;
+    private $url = null;
 
 /**
  * Class constructor.
  *
- * @param string $value     Outcome value (optional, default is none)
+ * @param string $value     Outcome score value (optional, default is none)
+ * @param string $text Outcome text value (optional, default is none)
+ * @param string $url Outcome url value (optional, default is none)
  */
-    public function __construct($value = null)
+    public function __construct($value = null, $text=null, $url=null)
     {
 
         $this->value = $value;
+        $this->text = $text;
+        $this->url = $url;
         $this->language = 'en-US';
         $this->date = gmdate('Y-m-d\TH:i:s\Z', time());
         $this->type = 'decimal';
@@ -90,5 +96,53 @@ class Outcome
         $this->value = $value;
 
     }
+
+	/**
+	 * Get the outcome text.
+	 *
+	 * @return string Outcome text
+	 */
+	public function getText()
+	{
+	
+		return $this->text;
+	
+	}
+	
+	/**
+	 * Set the outcome text.
+	 *
+	 * @param string $text  Outcome text
+	 */
+	public function setText($text)
+	{
+	
+		$this->text = $text;
+	
+	}
+	
+	/**
+	 * Get the outcome url.
+	 *
+	 * @return string Outcome url
+	 */
+	public function getUrl()
+	{
+	
+		return $this->url;
+	
+	}
+	
+	/**
+	 * Set the outcome url.
+	 *
+	 * @param string $url  Outcome url
+	 */
+	public function setUrl($url)
+	{
+	
+		$this->url = $url;
+	
+	}
 
 }

--- a/src/ToolProvider/ResourceLink.php
+++ b/src/ToolProvider/ResourceLink.php
@@ -584,9 +584,18 @@ class ResourceLink
             }
         }
         if (isset($do)) {
+        	//get the params
             $value = $ltiOutcome->getValue();
             if (is_null($value)) {
                 $value = '';
+            }
+            $text = $ltiOutcome->getText();
+            if (is_null($text)) {
+            	$text = '';
+            }
+            $url = $ltiOutcome->getUrl();
+            if (is_null($url)) {
+            	$url = '';
             }
             if ($urlLTI11) {
                 $xml = '';
@@ -598,6 +607,10 @@ class ResourceLink
             <language>{$ltiOutcome->language}</language>
             <textString>{$value}</textString>
           </resultScore>
+          <resultData>
+            <text><![CDATA[{$text}]]></text>
+            <url><![CDATA[{$url}]]></url>
+          </resultData>
         </result>
 EOF;
                 }


### PR DESCRIPTION
Lets optional 'text' and 'url' outcome parameters be written back to the LMS, as is supported by Canvas (not sure how well this is supported by other LMSes). 