### PR TITLE
When cURL is not available, response was not set

### DIFF
--- a/src/HTTPMessage.php
+++ b/src/HTTPMessage.php
@@ -166,6 +166,7 @@ class HTTPMessage
                 if ($fp) {
                     $resp = @stream_get_contents($fp);
                     $this->ok = $resp !== false;
+                    $this->response = $resp;
                 }
             } catch (\Exception $e) {
                 $this->ok = false;


### PR DESCRIPTION
When cURL is not available, HTTPMessage falls back to fopen.

The output of fopen was not set to `$this->response`. This PR fixes that.