### PR TITLE
Add support for passing extra resultData back to a consumer.

### DIFF
--- a/src/ToolProvider/Outcome.php
+++ b/src/ToolProvider/Outcome.php
@@ -53,14 +53,22 @@ class Outcome
     private $value = null;
 
 /**
+ * Outcome result data passback.
+ *
+ * @var array $resultData (type=>value)
+ */
+    private $resultData = null;
+
+
+/**
  * Class constructor.
  *
  * @param string $value     Outcome value (optional, default is none)
  */
-    public function __construct($value = null)
+    public function __construct($value = null, $resultData = null)
     {
-
         $this->value = $value;
+        $this->resultData = $resultData;
         $this->language = 'en-US';
         $this->date = gmdate('Y-m-d\TH:i:s\Z', time());
         $this->type = 'decimal';
@@ -88,6 +96,30 @@ class Outcome
     {
 
         $this->value = $value;
+
+    }
+
+/**
+ * Get the outcome result data.
+ *
+ * @return array Outcome Result Data (type=>value)
+ */
+    public function getResultData()
+    {
+
+        return $this->resultData;
+
+    }
+
+/**
+ * Set the outcome result data.
+ *
+ * @param array $resultData  Outcome result (type=>value)
+ */
+    public function setResultData($resultData)
+    {
+
+        $this->resultData = $resultData;
 
     }
 

--- a/src/ToolProvider/ResourceLink.php
+++ b/src/ToolProvider/ResourceLink.php
@@ -591,6 +591,19 @@ class ResourceLink
             if ($urlLTI11) {
                 $xml = '';
                 if ($action === self::EXT_WRITE) {
+                    $xmlResultAppend = null;
+                    if($ltiOutcome->getResultData() && is_array($ltiOutcome->getResultData())) {
+                        $resultData = $ltiOutcome->getResultData();
+                        reset($resultData);
+                        $resultKey = key($resultData);
+                        $resultValue = current($resultData);
+                        $xmlResultAppend = <<<EOF
+                        <resultData>
+                            <{$resultKey}>{$resultValue}</{$resultKey}>
+                        </resultData>
+EOF;
+
+                    }
                     $xml = <<<EOF
 
         <result>
@@ -598,6 +611,7 @@ class ResourceLink
             <language>{$ltiOutcome->language}</language>
             <textString>{$value}</textString>
           </resultScore>
+          {$xmlResultAppend}
         </result>
 EOF;
                 }


### PR DESCRIPTION
This allows providers to pass arbitrary content back with the outcome.  Canvas supports three types - url, text, or an LTI address.  Outcome now takes a second optional parameter - a resultData array with key (one of: url, text, ltiLaunchUrl) and a value.  