### PR TITLE
change SERVER_NAME with HTTP_HOST to get correct URL

### DIFF
--- a/src/OAuth/OAuthRequest.php
+++ b/src/OAuth/OAuthRequest.php
@@ -39,7 +39,7 @@ class OAuthRequest {
                 ? 'http'
                 : 'https';
       $http_url = ($http_url) ? $http_url : $scheme .
-                                '://' . $_SERVER['SERVER_NAME'] .
+                                '://' . $_SERVER['HTTP_HOST'] .
                                 ':' .
                                 $_SERVER['SERVER_PORT'] .
                                 $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
When using double subdomains like 'www.testing.ourcompany.com', the SERVER_NAME will return 'testing.ourcompany.com', while the HTTP_HOST returns the entire host. This url is used to create an oauth signature and this signature will differ. It's better to always use the entire url here.